### PR TITLE
fix(KUI-1102): only find start date if memo defined

### DIFF
--- a/server/controllers/memoCtrl.js
+++ b/server/controllers/memoCtrl.js
@@ -187,7 +187,9 @@ async function getContent(req, res, next) {
     const memoDatas = enrichMemoDatasWithOutdatedFlag(rawMemos, roundInfos)
     const memoWithExtraProps = await findMemoWithMatchingEndpoint(memoDatas, finalMemoEndPoint)
 
-    memoWithExtraProps.startDate = await findStartDateForMemo(memoWithExtraProps, roundInfos)
+    if (memoWithExtraProps) {
+      memoWithExtraProps.startDate = await findStartDateForMemo(memoWithExtraProps, roundInfos)
+    }
 
     const allTypeMemos = !memoWithExtraProps ? await getMiniMemosPdfAndWeb(courseCode) : []
 


### PR DESCRIPTION
findStartDateForMemo should only be called if we have a memo, otherwise we cannot access necessary information