### PR TITLE
Issues/KUI-1160 fix render mismatch

### DIFF
--- a/public/js/app/pages/CourseMemo.jsx
+++ b/public/js/app/pages/CourseMemo.jsx
@@ -99,6 +99,10 @@ function CourseMemo() {
 
   const [sourceUrl, setSourceUrl] = useState(null)
 
+  function hasNoMemoData() {
+    return Object.keys(memo).length === 0 && memo.constructor === Object
+  }
+
   useEffect(() => {
     let isMounted = true
     if (isMounted) {
@@ -145,10 +149,6 @@ function CourseMemo() {
 
   function isMemoArchived() {
     return isMemoOld() || isMemoOutdated()
-  }
-
-  function hasNoMemoData() {
-    return Object.keys(memo).length === 0 && memo.constructor === Object
   }
 
   function resolveLatestMemoUrl() {

--- a/public/js/app/pages/CourseMemo.jsx
+++ b/public/js/app/pages/CourseMemo.jsx
@@ -166,6 +166,13 @@ function CourseMemo() {
     }
     return null
   }
+
+  const [latestMemoUrl, setLatestMemoUrl] = useState(null)
+
+  useEffect(() => {
+    setLatestMemoUrl(resolveLatestMemoUrl())
+  }, [])
+
   return (
     <Container fluid>
       <CoverPage
@@ -203,7 +210,7 @@ function CourseMemo() {
               oldMemo={isMemoOld()}
               outdatedMemo={isMemoOutdated()}
               latestMemoLabel={webContext.latestMemoLabel}
-              latestMemoUrl={resolveLatestMemoUrl()}
+              latestMemoUrl={latestMemoUrl}
               courseImageUrl={courseImageUrl}
             />
             <Row>


### PR DESCRIPTION
Cpyress-tests encountered a mismatch between SSR code and the first render on the client side.
This was resolved by putting the mismatching variable into state, setting the initial value to the same value it has on the server and updating the value on first render using a useEffect.

Also ran into problems with eslint and had to move one function.