### PR TITLE
feat(KUI-1281): add support for fallback to kth-style 9 cortina blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@kth/api-call": "^4.1.0",
         "@kth/kth-node-response": "^1.0.7",
-        "@kth/kth-node-web-common": "^9.1.0",
+        "@kth/kth-node-web-common": "^9.2.0",
         "@kth/kth-reactstrap": "^0.4.78",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.2.1",
@@ -3239,16 +3239,16 @@
       "integrity": "sha512-iXRZLTSaIpuGEvZ7no9KUEp2+YATyuqdm72kglxGJCXRwIFhBDLRb9rHgUkuxu8fhhNtv8nH7F9v4Q2HhJL/cw=="
     },
     "node_modules/@kth/kth-node-web-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@kth/kth-node-web-common/-/kth-node-web-common-9.1.0.tgz",
-      "integrity": "sha512-zmsVvtlfwU+Jht0uYnKX+l+U0Pd6Vef8lKVa6YL5Q+FsKaeRGf0AgSnvPVnT8JxP0F/Zm6ax/sNbbeUJa7SQoQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@kth/kth-node-web-common/-/kth-node-web-common-9.2.0.tgz",
+      "integrity": "sha512-mjTPxreqwP1C/htWdJ63l9oHeTvJJjx70Z4qeYm1+DTEPZpEZK1tSEr+ZrmfIqiQHQM4sBGURaIwRqTmnd1vDg==",
       "dependencies": {
         "@kth/cortina-block": "^5.1.1",
         "@kth/log": "^4.0.7",
         "entities": "^2.2.0",
         "handlebars": "^4.7.8",
         "kth-node-i18n": "^1.0.18",
-        "kth-node-redis": "^3.2.0",
+        "kth-node-redis": "^3.3.0",
         "locale": "^0.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@kth/api-call": "^4.1.0",
     "@kth/kth-node-response": "^1.0.7",
-    "@kth/kth-node-web-common": "^9.1.0",
+    "@kth/kth-node-web-common": "^9.2.0",
     "@kth/kth-reactstrap": "^0.4.78",
     "@kth/log": "^4.0.7",
     "@kth/monitor": "^4.2.1",

--- a/server/server.js
+++ b/server/server.js
@@ -160,6 +160,7 @@ server.use(
     globalLink: config.blockApi.globalLink,
     addBlocks: config.blockApi.addBlocks,
     redisKey: config.cache.cortinaBlock.redisKey,
+    useStyle10: false,
   })
 )
 


### PR DESCRIPTION
Upgrade @kth/kth-node-web-common to 9.2.0 that adds support for fallback to kth-style 9 Cortina blocks.