### PR TITLE
Issue/k UI 1600 remove fields

### DIFF
--- a/i18n/messages.en.js
+++ b/i18n/messages.en.js
@@ -147,7 +147,6 @@ module.exports = {
     teacherAssistantsTitle: 'Teacher Assistants',
     examinerTitle: 'Examiner',
     otherContactsTitle: 'Other Contacts',
-    infoContactName: 'Course Contact',
   },
   extraInfo: {
     season: {

--- a/i18n/messages.se.js
+++ b/i18n/messages.se.js
@@ -118,7 +118,6 @@ module.exports = {
     teacherAssistantsTitle: 'Lärarassistenter',
     examinerTitle: 'Examinator',
     otherContactsTitle: 'Övriga kontakter',
-    infoContactName: 'Kontaktperson',
   },
   extraInfo: {
     season: {

--- a/public/js/app/components/AboutCourseContacts.jsx
+++ b/public/js/app/components/AboutCourseContacts.jsx
@@ -4,22 +4,6 @@ import { EMPTY } from '../util/constants'
 import HtmlWrapper from './HtmlWrapper'
 
 // Mandatory information
-const InfoContact = ({ languageIndex, infoContactName, labels }) =>
-  infoContactName ? (
-    <>
-      <h3 className="t4">{labels.infoContactName}</h3>
-      <HtmlWrapper id="links-info-contact-name" html={infoContactName} />
-    </>
-  ) : (
-    <>
-      <h3 className="t4">{labels.infoContactName}</h3>
-      <p>
-        <i>{EMPTY[languageIndex]}</i>
-      </p>
-    </>
-  )
-
-// Mandatory information
 const ExaminerContacts = ({ languageIndex, examiners, labels }) =>
   examiners ? (
     <>
@@ -35,10 +19,9 @@ const ExaminerContacts = ({ languageIndex, examiners, labels }) =>
     </>
   )
 
-const CourseContacts = ({ languageIndex, infoContactName = '', examiners = '', labels = {} }) => (
+const CourseContacts = ({ languageIndex, examiners = '', labels = {} }) => (
   <>
     <div className="info-box text-break">
-      <InfoContact languageIndex={languageIndex} infoContactName={infoContactName} labels={labels} />
       <ExaminerContacts languageIndex={languageIndex} examiners={examiners} labels={labels} />
     </div>
   </>

--- a/public/js/app/pages/AboutCourseMemo.jsx
+++ b/public/js/app/pages/AboutCourseMemo.jsx
@@ -367,7 +367,6 @@ function AboutCourseMemo({ mockKursPmDataApi = false, mockMixKoppsApi = false })
               <h2>{courseContactsLabels.courseContactsTitle}</h2>
               <AboutCourseContacts
                 languageIndex={userLanguageIndex}
-                infoContactName={webContext.infoContactName}
                 examiners={webContext.examiners}
                 labels={courseContactsLabels}
               />

--- a/public/js/app/pages/__tests__/AboutCourseMemoEN.test.js
+++ b/public/js/app/pages/__tests__/AboutCourseMemoEN.test.js
@@ -87,7 +87,7 @@ describe('User language: English. Component <AboutCourseMemo> show all memos: pd
     const mainContent = screen.getByRole('main')
 
     const allH3Headers = within(mainContent).getAllByRole('heading', { level: 3 })
-    expect(allH3Headers.length).toBe(5)
+    expect(allH3Headers.length).toBe(4)
     const expectedh3ds = [
       'Course offerings starting Autumn 2020',
       'Course offerings starting Autumn 2019',
@@ -109,7 +109,7 @@ describe('User language: English. Component <AboutCourseMemo> show all memos: pd
 
   test('renders text about empty fields (Course Contact, Examiner) ', () => {
     const noInfo = getAllByText('No information inserted')
-    expect(noInfo.length).toBe(2)
+    expect(noInfo.length).toBe(1)
   })
 
   test('renders menu link of web-based memo as expected', () => {

--- a/public/js/app/pages/__tests__/AboutCourseMemoSV.test.js
+++ b/public/js/app/pages/__tests__/AboutCourseMemoSV.test.js
@@ -88,7 +88,7 @@ describe('User language: Swedish. Component <AboutCourseMemo> show all memos: pd
   test('renders h3 ', () => {
     const mainContent = screen.getByRole('main')
     const allH3Headers = within(mainContent).getAllByRole('heading', { level: 3 })
-    expect(allH3Headers.length).toBe(5)
+    expect(allH3Headers.length).toBe(4)
     const expectedh3ds = [
       'Kursomgångar som startar HT 2020',
       'Kursomgångar som startar HT 2019',
@@ -106,11 +106,6 @@ describe('User language: Swedish. Component <AboutCourseMemo> show all memos: pd
       'HT 2019 (Startdatum 2023-01-17)',
     ]
     expectedh4ds.map((h4, index) => expect(allH4Headers[index]).toHaveTextContent(h4))
-  })
-
-  test('renders text about empty fields (Kontaktperson) ', () => {
-    const noInfo = getAllByText('Ingen information tillagd')
-    expect(noInfo.length).toBe(1)
   })
 
   test('renders menu link of web-based memo as expected', done => {

--- a/server/controllers/memoCtrl.js
+++ b/server/controllers/memoCtrl.js
@@ -200,23 +200,17 @@ async function getContent(req, res, next) {
 
     let fromTerm = semester ?? extractTerm(courseCode, finalMemoEndPoint)
 
-    const {
-      courseMainSubjects,
-      recruitmentText,
-      title,
-      credits,
-      creditUnitAbbr,
-      infoContactName,
-      examiners,
-      roundInfos,
-    } = await getDetailedInformation(courseCode, languagesContext.memoLanguage, fromTerm)
+    const { courseMainSubjects, title, credits, creditUnitAbbr, examiners, roundInfos } = await getDetailedInformation(
+      courseCode,
+      languagesContext.memoLanguage,
+      fromTerm
+    )
 
     const courseContext = {
       courseMainSubjects,
       title,
       credits,
       creditUnitAbbr,
-      infoContactName,
       examiners,
     }
 
@@ -330,15 +324,16 @@ async function getOldContent(req, res, next) {
       memoDatas: [],
     }
 
-    const { courseMainSubjects, recruitmentText, title, credits, creditUnitAbbr, infoContactName, examiners } =
-      await getDetailedInformation(courseCode, languagesContext.memoLanguage)
+    const { courseMainSubjects, title, credits, creditUnitAbbr, examiners } = await getDetailedInformation(
+      courseCode,
+      languagesContext.memoLanguage
+    )
 
     const courseContext = {
       courseMainSubjects,
       title,
       credits,
       creditUnitAbbr,
-      infoContactName,
       examiners,
     }
 
@@ -416,7 +411,7 @@ async function getAboutContent(req, res, next) {
 
     const fromTerm = getLastYearsTerm()
 
-    const { title, credits, creditUnitAbbr, infoContactName, examiners, roundInfos } = await getDetailedInformation(
+    const { title, credits, creditUnitAbbr, examiners, roundInfos } = await getDetailedInformation(
       courseCode,
       responseLanguage,
       fromTerm
@@ -424,7 +419,6 @@ async function getAboutContent(req, res, next) {
     webContext.title = title
     webContext.credits = credits
     webContext.creditUnitAbbr = creditUnitAbbr
-    webContext.infoContactName = infoContactName
     webContext.examiners = examiners
 
     webContext.memoDatas = enrichMemoDatasWithOutdatedFlag(rawMemos, roundInfos)

--- a/server/koppsApi.js
+++ b/server/koppsApi.js
@@ -67,7 +67,6 @@ async function getDetailedInformation(courseCode, language, fromTerm) {
         title: course && course.title ? course.title : '',
         credits: isCreditNotStandard ? course.credits + '.0' : course.credits || '',
         creditUnitAbbr: course && course.creditUnitAbbr ? course.creditUnitAbbr : '',
-        infoContactName: course && course.infoContactName ? course.infoContactName : '',
         examiners: createPersonHtml(examiners),
         roundInfos: roundInfos || [],
       }

--- a/server/ssr-context/createServerSideContext.js
+++ b/server/ssr-context/createServerSideContext.js
@@ -24,7 +24,6 @@ function createServerSideContext() {
     title: '',
     credits: '',
     creditUnitAbbr: '',
-    infoContactName: '',
     semester: '',
     examiners: '',
     userLanguageIndex: 1,

--- a/test/mock-api/responses.js
+++ b/test/mock-api/responses.js
@@ -41,7 +41,6 @@ module.exports = {
       extraHeaders4: '',
       extraHeaders5: '',
       equipment: '',
-      infoContactName: '',
       literature: '',
       possibilityToCompletion: '',
       possibilityToAddition: '',


### PR DESCRIPTION
The heading `infoContactName` from the page /om-kurs-pm (e.g. https://www-r.referens.sys.kth.se/kurs-pm/SF1610/om-kurs-pm ) should be removed.