### PR TITLE
Issues/KUI 2016 handle courses without memos

### DIFF
--- a/i18n/messages.en.js
+++ b/i18n/messages.en.js
@@ -238,6 +238,7 @@ module.exports = {
     previousOfferingsText: 'Course memos for previous course offerings are displayed on the ',
     previousOfferings: 'Previous course offerings',
     startdate: 'Start date',
+    noMemos: 'This course has no published course memos.',
   },
   breadCrumbs: {
     student: 'Student web',

--- a/i18n/messages.se.js
+++ b/i18n/messages.se.js
@@ -209,6 +209,7 @@ module.exports = {
     previousOfferingsText: 'Kurs-PM för tidigare kursomgångar visas på sidan ',
     previousOfferings: 'Tidigare kursomgångar',
     startdate: 'Startdatum',
+    noMemos: 'Denna kurs har inga publicerade kurs-PM.',
   },
   breadCrumbs: {
     student: 'Studentwebben',

--- a/public/css/kurs-pm-web.scss
+++ b/public/css/kurs-pm-web.scss
@@ -159,3 +159,7 @@ h2:has(+ .info-box) {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.inline-information {
+  font-style: italic;
+}

--- a/public/js/app/pages/AboutCourseMemo.jsx
+++ b/public/js/app/pages/AboutCourseMemo.jsx
@@ -302,8 +302,8 @@ function AboutCourseMemo() {
                 btnClose={aboutMemoLabels.btnClose}
                 withModal
               />
-              {allActiveTermsWithRounds.map(({ semester, memos }) => {
-                return (
+              {allActiveTermsWithRounds.length ? (
+                allActiveTermsWithRounds.map(({ semester, memos }) => (
                   <React.Fragment key={semester}>
                     <h3>{`${aboutMemoLabels.currentOfferings} ${seasonStr(extraInfo, semester)}`}</h3>
                     {memos.map(memo => (
@@ -333,13 +333,19 @@ function AboutCourseMemo() {
                       </React.Fragment>
                     ))}
                   </React.Fragment>
-                )
-              })}
-              <h3>{aboutMemoLabels.previousOfferings}</h3>
-              <p>
-                {aboutMemoLabels.previousOfferingsText}
-                <a href={linkToArchive(courseCode, userLangAbbr)}>{courseMemoLinksLabels.archivePageLabel}</a>
-              </p>
+                ))
+              ) : (
+                <p className="inline-information">{aboutMemoLabels.noMemos}</p>
+              )}
+              {allActiveTermsWithRounds.length > 0 && (
+                <>
+                  <h3>{aboutMemoLabels.previousOfferings}</h3>
+                  <p>
+                    {aboutMemoLabels.previousOfferingsText}
+                    <a href={linkToArchive(courseCode, userLangAbbr)}>{courseMemoLinksLabels.archivePageLabel}</a>
+                  </p>
+                </>
+              )}
             </section>
           </Col>
           <Col lg="4" className="content-right">

--- a/public/js/app/pages/__tests__/AboutCourseMemoEN.test.js
+++ b/public/js/app/pages/__tests__/AboutCourseMemoEN.test.js
@@ -7,7 +7,7 @@ import { WebContextProvider } from '../../context/WebContext'
 import AboutCourseMemo from '../AboutCourseMemo'
 import { mockMixLadokApi, mockMixKursPmDataApi } from '../mockApis'
 
-const { getAllByRole, getAllByText, getByText } = screen
+const { getAllByRole, getAllByText, getByText, queryAllByRole } = screen
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => ({
@@ -211,5 +211,47 @@ describe('User language: English. Component <AboutCourseMemo> show all memos: pd
       'Archive',
     ]
     expectedlinks.map((link, index) => expect(links[index]).toHaveTextContent(link))
+  })
+})
+
+describe('User language: English. Component <AboutCourseMemo> when there are no course memos', () => {
+  beforeEach(() => {
+    const context = {
+      courseCode: 'KIP9999',
+      browserConfig: { memoStorageUri: 'kursinfostorage/' },
+      memoData: {
+        courseTitle: 'KIP9999 Imaginary course',
+        visibleInMemo: {},
+      },
+      memoDatas: [], // no memos
+      allTypeMemos: {}, // empty
+      allRoundInfos: [], // no rounds
+      language: 'en',
+      userLanguageIndex: 0,
+    }
+
+    render(
+      <MemoryRouter>
+        <WebContextProvider configIn={context}>
+          <AboutCourseMemo location={{}} />
+        </WebContextProvider>
+      </MemoryRouter>
+    )
+  })
+
+  test('renders "no memos" message', () => {
+    expect(screen.getByText('This course has no published course memos.')).toBeInTheDocument()
+  })
+
+  test('does not render any h4 memo headings', () => {
+    expect(screen.queryAllByRole('heading', { level: 4 }).length).toBe(0)
+  })
+
+  test('renders Archive page link even if no memos', () => {
+    const archiveLinks = screen.getAllByText('Archive page')
+    expect(archiveLinks.length).toBeGreaterThan(0)
+    archiveLinks.forEach(link => {
+      expect(link).toHaveAttribute('href', expect.stringContaining('/arkiv?l=en'))
+    })
   })
 })

--- a/public/js/app/pages/__tests__/AboutCourseMemoSV.test.js
+++ b/public/js/app/pages/__tests__/AboutCourseMemoSV.test.js
@@ -208,3 +208,45 @@ describe('User language: Swedish. Component <AboutCourseMemo> show all memos: pd
     done()
   })
 })
+
+describe('User language: Swedish. Component <AboutCourseMemo> when there are no course memos', () => {
+  beforeEach(() => {
+    const context = {
+      courseCode: 'KIP9999',
+      browserConfig: { memoStorageUri: 'kursinfostorage/' },
+      memoData: {
+        courseTitle: 'KIP9999 Påhittad kurs',
+        visibleInMemo: {},
+      },
+      memoDatas: [], // no memos
+      allTypeMemos: {}, // empty
+      allRoundInfos: [], // no rounds
+      language: 'sv',
+      userLanguageIndex: 1,
+    }
+
+    render(
+      <MemoryRouter>
+        <WebContextProvider configIn={context}>
+          <AboutCourseMemo location={{}} />
+        </WebContextProvider>
+      </MemoryRouter>
+    )
+  })
+
+  test('renders "no memos" message', () => {
+    expect(screen.getByText('Denna kurs har inga publicerade kurs-PM.')).toBeInTheDocument()
+  })
+
+  test('does not render any h4 memo headings', () => {
+    expect(screen.queryAllByRole('heading', { level: 4 }).length).toBe(0)
+  })
+
+  test('renders Archive page link even if no memos', () => {
+    const archiveLinks = screen.getAllByText('Arkiv')
+    expect(archiveLinks.length).toBeGreaterThan(0)
+    archiveLinks.forEach(link => {
+      expect(link).toHaveAttribute('href', expect.stringContaining('/arkiv'))
+    })
+  })
+})

--- a/server/ladokApi.js
+++ b/server/ladokApi.js
@@ -7,10 +7,8 @@ const serverConfig = require('./configuration').server
 async function getLadokCourseData(courseCode, lang) {
   const client = createApiClient(serverConfig.ladokMellanlagerApi)
   const course = await client.getLatestCourseVersion(courseCode, lang)
-  const {
-    benamning: ladokCourseTitle,
-    omfattning: { formattedWithUnit: ladokCreditsLabel },
-  } = course
+  const ladokCourseTitle = course?.benamning
+  const ladokCreditsLabel = course?.omfattning?.formattedWithUnit
 
   return {
     title: ladokCourseTitle ?? '',


### PR DESCRIPTION
## 📌 Summary

This PR contains bug fix for `kurs-pm-web` crashing for courses without course memos.

Fixes https://kth-se.atlassian.net/browse/KUI-2016

---

## 🔍 Changes

- Handles courses for which there are no course memos.
- Added tests for courses without memos.

---

## ✅ Checklist (Author)

- [ ] Code builds locally without errors
- [ ] Tests added/updated and passing
- [ ] Linting/formatting applied
- [ ] No sensitive data in the diff
- [ ] No stray console.logs in the diff
- [ ] No stray comments in the diff
- [ ] Docs/README/CHANGELOG updated (if needed)
- [ ] Sufficient logging
- [ ] Errors are handled accordingly

---

## 🧪 Testing & Verification

Test locally by looking at 

http://localhost:3000/kurs-pm/AD12DA/om-kurs-pm
* Should not return 500
* Should show _Denna kurs har inga publicerade kurs-PM._ under the heading _Kurs-PM_

http://localhost:3000/kurs-pm/SF1624/om-kurs-pm
* Should not return 500
* Should show list of course memos (fore those instances with published memos) under the heading _Kurs-PM_

---

## ⚠️ Impact / Risks

No known impacts/risks.

---

## 🚧 Out of Scope

Didn't take care of all linting warnings found in this project.

---

## 📦 Downstream apps

No other apps are impacted.