### PR TITLE
KUI-1479: fetch the firstTuitionDate for old course memos

### DIFF
--- a/server/controllers/memoCtrl.js
+++ b/server/controllers/memoCtrl.js
@@ -300,8 +300,12 @@ async function getOldContent(req, res, next) {
 
     rawContext.setBrowserConfig(browser, serverPaths, apis, serverConfig.hostUrl)
 
+    const roundInfos = await getCourseRoundsFromLastYear(courseCode, responseLanguage)
     const versionMemo = await getMemoVersion(courseCode, memoEndPoint, version)
     const allTypeMemos = !versionMemo ? await getMiniMemosPdfAndWeb(courseCode) : []
+
+    const memoRound = await getMemoRoundFromRoundInfosOrApi(versionMemo, roundInfos, responseLanguage)
+    versionMemo.startDate = memoRound.firstTuitionDate
 
     const languagesContext = {
       language: responseLanguage,

--- a/server/controllers/memoCtrl.js
+++ b/server/controllers/memoCtrl.js
@@ -303,9 +303,8 @@ async function getOldContent(req, res, next) {
     const roundInfos = await getCourseRoundsFromLastYear(courseCode, responseLanguage)
     const versionMemo = await getMemoVersion(courseCode, memoEndPoint, version)
     const allTypeMemos = !versionMemo ? await getMiniMemosPdfAndWeb(courseCode) : []
-
-    const memoRound = await getMemoRoundFromRoundInfosOrApi(versionMemo, roundInfos, responseLanguage)
-    versionMemo.startDate = memoRound.firstTuitionDate
+    const memoRound = await getMemoRoundFromRoundInfosOrApi(versionMemo, roundInfos, versionMemo?.memoCommonLangAbbr)
+    versionMemo.startDate = memoRound?.firstTuitionDate
 
     const languagesContext = {
       language: responseLanguage,

--- a/server/ladokApi.js
+++ b/server/ladokApi.js
@@ -7,7 +7,7 @@ const serverConfig = require('./configuration').server
 async function getLadokCourseData(courseCode, lang) {
   const client = createApiClient(serverConfig.ladokMellanlagerApi)
   const course = await client.getLatestCourseVersionIncludingCancelled(courseCode, lang)
-  const ladokCourseTitle = course?.benamning.name
+  const ladokCourseTitle = course?.benamning?.name
   const ladokCreditsLabel = course?.omfattning?.formattedWithUnit
 
   return {


### PR DESCRIPTION
## 📌 Summary

<!-- Explain what this PR does and why. Link issues if relevant. -->

Fixes https://kth-se.atlassian.net/browse/1479

---

## 🔍 Changes

<!-- Bullet points of main changes -->

- roundInfos.firstTuitionDate was used for the latest course memos, but not old ones, causing the startDate to not show. Implemented the same logic for getOldContent where we compare the applicationCodes and extract firstTuitionDate that way.
- Added null check for benamning

---

## ✅ Checklist (Author)

- [x] Code builds locally without errors
- [x] Tests added/updated and passing
- [x] Linting/formatting applied
- [x] No sensitive data in the diff
- [x] No stray console.logs in the diff
- [x] No stray comments in the diff
- [x] Docs/README/CHANGELOG updated (if needed)
- [x] Sufficient logging
- [x] Errors are handled accordingly

---

## 🧪 Testing & Verification

<!-- what has been done in terms of unit/automated tests -->
<!--- how to test/confirm manually -->
<!-- How did you test this? Steps/screenshots for reviewers. -->

1. Test suite passes
2. Tested with some course memos set to 'old' to see that the start date is the same as when it was the latest version.

3. For local testing:
- Run kurs-pm-data-admin-web and kurs-pm-data-api locally.
- Visit [the page for editing course memos](http://localhost:3000/kursinfoadmin/kurs-pm-data/published/SF1624/)
- Edit an already existing course memo version and publish it as a new version. Keep in mind the start date.
- Visit [kursutveckling-web / archive](https://www-r.referens.sys.kth.se/kursutveckling/SF1624/arkiv?l=en) and visit the page for the old version of the course memo that you just published.
- The old version should have the same start date as when it was the most recent version

Screenshots / recordings (if UI change):

---

## ⚠️ Impact / Risks

<!-- Any breaking changes, side effects, or areas to double-check -->
<!-- important things to do when releasing -->

---

## 🚧 Out of Scope

<!-- Anything intentionally left for later (optional) -->

---

## 📦 Downstream apps

<!-- Which public APIs are affected? -->
<!-- Which apps consume functions that have been changed by this PR and need to be updated/tested? -->